### PR TITLE
chore: release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.1](https://github.com/ggagosh/arcula/releases/tag/v1.0.1) - 2025-05-17
+
+### Fixed
+
+- fixes
+- fix fmt
+- fix tools
+
+### Other
+
+- rename
+- 1.0.0
+- rlit
+- remove build
+- name change ci
+- test
+- init


### PR DESCRIPTION



## 🤖 New release

* `arcula`: 1.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.1](https://github.com/ggagosh/arcula/releases/tag/v1.0.1) - 2025-05-17

### Fixed

- fixes
- fix fmt
- fix tools

### Other

- rename
- 1.0.0
- rlit
- remove build
- name change ci
- test
- init
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).