### PR TITLE
chore: release v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.5](https://github.com/ggagosh/arcula/compare/v1.0.4...v1.0.5) - 2025-05-19
+
+### Other
+
+- Update Cargo.toml with repository, categories, and keywords
+- Add author note to README explaining project purpose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arcula"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arcula"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 description = "Arcula - MongoDB database synchronization tool"
 authors = ["gagosha <me@gagosha.dev>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 description = "Arcula - MongoDB database synchronization tool"
 authors = ["gagosha <me@gagosha.dev>"]
 license = "MIT"
+repository = "https://github.com/ggagosh/arcula"
+categories = ['command-line-utilities', 'database']
+keywords = ["mongodb", "sync", "database", "cli"]
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `arcula`: 1.0.4 -> 1.0.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.5](https://github.com/ggagosh/arcula/compare/v1.0.4...v1.0.5) - 2025-05-19

### Other

- Update Cargo.toml with repository, categories, and keywords
- Add author note to README explaining project purpose
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).