### PR TITLE
chore: release v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.6](https://github.com/ggagosh/arcula/compare/v1.0.5...v1.0.6) - 2025-12-24
+
+### Other
+
+- Fix --nsInclude usage
+- Remove deprecated --db flag from mongorestore
+
 ## [1.0.5](https://github.com/ggagosh/arcula/compare/v1.0.4...v1.0.5) - 2025-05-19
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arcula"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arcula"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 description = "Arcula - MongoDB database synchronization tool"
 authors = ["gagosha <me@gagosha.dev>"]


### PR DESCRIPTION



## 🤖 New release

* `arcula`: 1.0.5 -> 1.0.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.6](https://github.com/ggagosh/arcula/compare/v1.0.5...v1.0.6) - 2025-12-24

### Other

- Fix --nsInclude usage
- Remove deprecated --db flag from mongorestore
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).