### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/ggagosh/arcula/compare/v1.0.6...v2.0.0) - 2026-05-05
+
+### Fixed
+
+- indexes
+
+### Other
+
+- Avoid DBus dependency for keyring
+- Add safe plan approval workflow
+- Small fixes
+
 ## [1.0.6](https://github.com/ggagosh/arcula/compare/v1.0.5...v1.0.6) - 2025-12-24
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0](https://github.com/ggagosh/arcula/compare/v1.0.6...v2.0.0) - 2026-05-05
 
+### Added
+
+- Added a secure connection manager backed by the OS credential store, with `connection add/list/show/test/remove/import-env` commands.
+- Added environment metadata and per-connection safety policy support for `kind`, `protected`, source/target permissions, agent apply, human approval, destructive backup, and backup verification.
+- Added agent-friendly output and execution controls: `--format json`, `--agent`, `--no-env`, `--no-color`, direct URI inputs, and URI kind overrides.
+- Added saved sync plans via `sync plan`, including plan hashes, policy snapshots, warnings, approval requirements, and human-readable/JSON rendering.
+- Added OS-backed approval records for protected plans via `plan approve`, with approval signatures bound to the exact plan hash.
+- Added operation records via `operation run/list/show`, including status history, approval metadata, sync reports, and errors.
+- Added operation revert support using the pre-sync target backup.
+
+### Changed
+
+- Destructive syncs to production/protected targets now require a full backup and, when policy requires it, the plan/approval/operation flow.
+- Direct target URI usage is treated as protected by default unless classified with `--to-kind`.
+- `info` now includes stored connections in addition to `.env` environments.
+- Linux secure storage now uses the kernel keyring backend to avoid a DBus development dependency in CI and headless builds.
+
 ### Fixed
 
-- indexes
+- Sync export/import failures now return errors instead of printing success.
+- Required backup failures now abort the sync before destructive target changes.
+- Failed imports attempt backup restoration but still return a failed operation.
+- MongoDB command errors are sanitized before being stored or emitted.
+- Docker integration tests now satisfy strict clippy checks.
 
-### Other
+### Breaking
 
-- Avoid DBus dependency for keyring
-- Add safe plan approval workflow
-- Small fixes
+- The public Rust API changed: `SyncParams` gained fields, `ConfigError` gained `ConnectionStore`, and the deprecated `commands::sync::execute` helper was removed.
 
 ## [1.0.6](https://github.com/ggagosh/arcula/compare/v1.0.5...v1.0.6) - 2025-12-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arcula"
-version = "1.0.6"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arcula"
-version = "1.0.6"
+version = "2.0.0"
 edition = "2021"
 description = "Arcula - MongoDB database synchronization tool"
 authors = ["gagosha <me@gagosha.dev>"]


### PR DESCRIPTION
## 🤖 New release

* `arcula`: `1.0.6` → `2.0.0`

This is a major release because the public Rust API changed (`SyncParams`, `ConfigError`, and the removed deprecated `commands::sync::execute` helper). The CLI remains focused on MongoDB environment sync, but now adds safer plan/approval/operation workflows and secure connection management.

## Highlights

### Secure connection manager

- Added named connection storage backed by the OS credential store.
- Added `arcula connection add/list/show/test/remove/import-env`.
- Added connection metadata and policy support: `kind`, `protected`, source/target permissions, agent apply, human approval, destructive backup, and backup verification.

### Agent-friendly sync

- Added JSON/agent controls: `--format json`, `--agent`, `--no-env`, `--no-color`.
- Added direct URI inputs and endpoint kind overrides for automation.
- JSON mode avoids prompts and returns structured success/error payloads.

### Safe plan/approval/operation flow

- Added `arcula sync plan` to save a non-mutating sync plan with a stable hash and policy snapshot.
- Added `arcula plan approve` for protected plans using local OS user-presence approval.
- Added `arcula operation run/list/show` with status history, approval metadata, sync report, and captured errors.
- Added `arcula operation revert` to restore the target from the pre-sync backup.

### Production/protected safeguards

- Destructive syncs to protected/production targets require a full backup.
- Protected targets can require the plan/approval/operation flow before execution.
- Direct target URIs are treated as protected unless explicitly classified.
- Backup/export/import failures now fail the command instead of printing success.

### CI/build fix

- Linux keyring support now uses the kernel keyring backend, avoiding a DBus development dependency in CI/headless builds.

## Changelog

See `CHANGELOG.md` in this PR for the full release notes.

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/) and its description was expanded manually for clarity.