### PR TITLE
chore: release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/ggagosh/arcula/compare/v2.0.0...v2.0.1) - 2026-05-11
+
+### Other
+
+- add Arcula agent skill
+- update project introduction
+
 ## [2.0.0](https://github.com/ggagosh/arcula/compare/v1.0.6...v2.0.0) - 2026-05-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arcula"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arcula"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 description = "Arcula - MongoDB database synchronization tool"
 authors = ["gagosha <me@gagosha.dev>"]


### PR DESCRIPTION



## 🤖 New release

* `arcula`: 2.0.0 -> 2.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.1](https://github.com/ggagosh/arcula/compare/v2.0.0...v2.0.1) - 2026-05-11

### Other

- add Arcula agent skill
- update project introduction
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).